### PR TITLE
feat/expenses

### DIFF
--- a/planning/stories.md
+++ b/planning/stories.md
@@ -78,9 +78,9 @@ Views and calculations to analyze financial data over time.
 ### Acceptance Criteria
 
 - [x] The system includes a predefined "NA" savings source that cannot be deleted
-- [ ] When a savings source is deleted, its value is automatically transferred to the "NA" source
-- [ ] The "NA" source appears in all financial records
-- [ ] The "NA" source is clearly labeled as a special source for unclassified money
+- [x] When a savings source is deleted, its value is automatically transferred to the "NA" source
+- [x] The "NA" source appears in all financial records
+- [x] The "NA" source is clearly labeled as a special source for unclassified money
 
 ---
 
@@ -109,7 +109,7 @@ Views and calculations to analyze financial data over time.
 - [x] Users can modify the name of the selected savings source
 - [x] System validates that the name is not empty and its length is less than 100 characters
 - [x] Changes are saved when submitted
-- [ ] The saving source used is updated across all financial records
+- [x] The saving source used is updated across all financial records
 - [x] User cannot update the "NA" savings source
 - [ ] Confirmation is shown when a savings source is updated
 
@@ -138,9 +138,9 @@ Views and calculations to analyze financial data over time.
 
 - [x] Users can select an existing savings source to delete
 - [x] System shows a confirmation dialog before deletion
-- [ ] When confirmed, system transfers any associated values to the "NA" savings source
+- [x] When confirmed, system transfers any associated values to the "NA" savings source
 - [x] The deleted savings source no longer appears in the list
-- [ ] The saving source stops appearing in all financial records
+- [x] The saving source stops appearing in all financial records
 - [ ] Confirmation is shown when a savings source is deleted
 
 ---
@@ -254,6 +254,30 @@ Views and calculations to analyze financial data over time.
 **I want** to update an existing financial record  
 **So that** I can correct errors or update values as needed
 
+---
+
+### Acceptance Criteria
+
+- [x] Users can select an existing financial record to edit
+- [x] Users can modify the values for each savings source
+- [x] The system updates the "updated at" timestamp automatically
+- [x] The system recalculates the total sum after modifications
+- [x] Changes are saved when submitted
+- [ ] Confirmation is shown when a financial record is updated
+
+---
+
+### Definition of Done
+
+- Code implemented
+- Unit tests written & passed
+- UI elements created and responsive
+- Meets acceptance criteria
+- Reviewed & merged
+- Deployed to staging/production
+
+---
+
 #### US009: Delete Financial Record
 
 **As a** user  
@@ -281,31 +305,9 @@ Views and calculations to analyze financial data over time.
 
 ---
 
-### Acceptance Criteria
-
-- [x] Users can select an existing financial record to edit
-- [x] Users can modify the values for each savings source
-- [x] The system updates the "updated at" timestamp automatically
-- [x] The system recalculates the total sum after modifications
-- [x] Changes are saved when submitted
-- [ ] Confirmation is shown when a financial record is updated
-
----
-
-### Definition of Done
-
-- Code implemented
-- Unit tests written & passed
-- UI elements created and responsive
-- Meets acceptance criteria
-- Reviewed & merged
-- Deployed to staging/production
-
----
-
 ### Epic: EP003 - Expense Tracking
 
-#### US009: Add Relevant Expenses to Financial Record
+#### US309: Add Relevant Expenses to Financial Record
 
 **As a** user  
 **I want** to add relevant expenses to a financial record  
@@ -315,9 +317,9 @@ Views and calculations to analyze financial data over time.
 
 ### Acceptance Criteria
 
-- [ ] Users can add one or more relevant expenses to a financial record
-- [ ] For each expense, users can enter a name and price in COP
-- [ ] Expenses are saved with the financial record
+- [x] Users can add one or more relevant expenses to a financial record
+- [x] For each expense, users can enter a name and price in COP
+- [x] Expenses are saved with the financial record
 - [ ] Confirmation is shown when expenses are added
 
 ---
@@ -333,7 +335,7 @@ Views and calculations to analyze financial data over time.
 
 ---
 
-#### US010: View Relevant Expenses
+#### US310: View Relevant Expenses
 
 **As a** user  
 **I want** to view all relevant expenses for a financial record  
@@ -343,10 +345,10 @@ Views and calculations to analyze financial data over time.
 
 ### Acceptance Criteria
 
-- [ ] Users can view a list of all relevant expenses within a financial record
-- [ ] Each expense displays its name and price in COP
-- [ ] The expenses are clearly associated with the specific financial record
-- [ ] The list is visually clear and readable
+- [x] Users can view a list of all relevant expenses within a financial record
+- [x] Each expense displays its name and price in COP
+- [x] The expenses are clearly associated with the specific financial record
+- [x] The list is visually clear and readable
 
 ---
 
@@ -361,7 +363,7 @@ Views and calculations to analyze financial data over time.
 
 ---
 
-#### US011: Edit or Remove Relevant Expenses
+#### US311: Edit or Remove Relevant Expenses
 
 **As a** user  
 **I want** to edit or remove expenses from a financial record  
@@ -371,10 +373,10 @@ Views and calculations to analyze financial data over time.
 
 ### Acceptance Criteria
 
-- [ ] Users can select an existing expense to edit
-- [ ] Users can modify the name and price of an expense
-- [ ] Users can delete an expense
-- [ ] Changes are saved when submitted
+- [x] Users can select an existing expense to edit
+- [x] Users can modify the name and price of an expense
+- [x] Users can delete an expense
+- [x] Changes are saved when submitted
 - [ ] Confirmation is shown when an expense is updated or removed
 
 ---

--- a/src/features/core/entities/expense.ts
+++ b/src/features/core/entities/expense.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 
 export interface Expense {
   id: string;
-  financialRecordId: string;
   name: string;
   amount: number;
   createdAt: Date;

--- a/src/features/core/pages/financial-records/components/add-expense-dialog.tsx
+++ b/src/features/core/pages/financial-records/components/add-expense-dialog.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { CreateExpenseInputSchema } from "../../../entities/expense";
+
+// Schema omits financialRecordId as it will be added when submitting
+const formSchema = z.object({
+  name: CreateExpenseInputSchema.shape.name,
+  amount: CreateExpenseInputSchema.shape.amount,
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+interface AddExpenseDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (data: FormData) => void;
+  isLoading: boolean;
+}
+
+export const AddExpenseDialog: React.FC<AddExpenseDialogProps> = ({
+  open,
+  onOpenChange,
+  onSubmit,
+  isLoading,
+}) => {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: "",
+      amount: 0,
+    },
+  });
+
+  // Reset form when dialog opens or closes
+  /* React.useEffect(() => {
+    if (!open) {
+      reset();
+    }
+  }, [open, reset]); */
+
+  const handleFormSubmit = handleSubmit((data) => {
+    onSubmit(data);
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Add Expense</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleFormSubmit}>
+          <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <Label htmlFor="name">Expense Name</Label>
+              <Input
+                id="name"
+                placeholder="Enter expense name"
+                {...register("name")}
+                className={errors.name ? "border-red-500" : ""}
+              />
+              {errors.name && (
+                <p className="text-sm text-red-500">{errors.name.message}</p>
+              )}
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="amount">Amount (COP)</Label>
+              <Input
+                id="amount"
+                type="number"
+                min="0"
+                step="0.01"
+                placeholder="Enter amount"
+                {...register("amount", { valueAsNumber: true })}
+                className={errors.amount ? "border-red-500" : ""}
+              />
+              {errors.amount && (
+                <p className="text-sm text-red-500">{errors.amount.message}</p>
+              )}
+            </div>
+          </div>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="outline">
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button type="submit" disabled={isLoading}>
+              {isLoading ? "Adding..." : "Add Expense"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/features/core/pages/financial-records/components/delete-expense-dialog.tsx
+++ b/src/features/core/pages/financial-records/components/delete-expense-dialog.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface DeleteExpenseDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  isLoading: boolean;
+  expenseName: string;
+}
+
+export const DeleteExpenseDialog: React.FC<DeleteExpenseDialogProps> = ({
+  open,
+  onOpenChange,
+  onConfirm,
+  isLoading,
+  expenseName,
+}) => {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete Expense</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to delete the expense "{expenseName}"? This
+            action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={isLoading}
+            className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+          >
+            {isLoading ? "Deleting..." : "Delete"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/src/features/core/pages/financial-records/components/edit-expense-dialog.tsx
+++ b/src/features/core/pages/financial-records/components/edit-expense-dialog.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { UpdateExpenseInputSchema } from "../../../entities/expense";
+
+// Schema for the form
+const formSchema = z.object({
+  name: UpdateExpenseInputSchema.shape.name,
+  amount: UpdateExpenseInputSchema.shape.amount,
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+interface EditExpenseDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (data: FormData) => void;
+  isLoading: boolean;
+  initialData: {
+    name: string;
+    amount: number;
+  };
+}
+
+export const EditExpenseDialog: React.FC<EditExpenseDialogProps> = ({
+  open,
+  onOpenChange,
+  onSubmit,
+  isLoading,
+  initialData,
+}) => {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: initialData,
+  });
+
+  // Reset form with initialData when dialog opens or initialData changes
+  /* React.useEffect(() => {
+    if (open && initialData) {
+      reset(initialData);
+    }
+  }, [open, initialData, reset]); */
+
+  const handleFormSubmit = handleSubmit((data) => {
+    onSubmit(data);
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Edit Expense</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleFormSubmit}>
+          <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <Label htmlFor="name">Expense Name</Label>
+              <Input
+                id="name"
+                placeholder="Enter expense name"
+                {...register("name")}
+                className={errors.name ? "border-red-500" : ""}
+              />
+              {errors.name && (
+                <p className="text-sm text-red-500">{errors.name.message}</p>
+              )}
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="amount">Amount (COP)</Label>
+              <Input
+                id="amount"
+                type="number"
+                min="0"
+                step="0.01"
+                placeholder="Enter amount"
+                {...register("amount", { valueAsNumber: true })}
+                className={errors.amount ? "border-red-500" : ""}
+              />
+              {errors.amount && (
+                <p className="text-sm text-red-500">{errors.amount.message}</p>
+              )}
+            </div>
+          </div>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="outline">
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button type="submit" disabled={isLoading}>
+              {isLoading ? "Saving..." : "Save Changes"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/features/core/pages/financial-records/components/expenses-list.tsx
+++ b/src/features/core/pages/financial-records/components/expenses-list.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import { Edit, Trash } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Expense } from "../../../entities/expense";
+import { formatCurrency } from "@/lib/formatters";
+
+interface ExpensesListProps {
+  expenses: Expense[];
+  onEdit: (expenseId: string) => void;
+  onDelete: (expenseId: string) => void;
+}
+
+export const ExpensesList: React.FC<ExpensesListProps> = ({
+  expenses,
+  onEdit,
+  onDelete,
+}) => {
+  // Calculate total expenses
+  const totalExpenses = expenses.reduce(
+    (total, expense) => total + expense.amount,
+    0
+  );
+
+  if (expenses.length === 0) {
+    return (
+      <div className="text-center py-8 text-muted-foreground">
+        <p>No expenses added yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Desktop view */}
+      <div className="hidden md:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Expense Name</TableHead>
+              <TableHead>Amount</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {expenses.map((expense) => (
+              <TableRow key={expense.id}>
+                <TableCell className="font-medium">{expense.name}</TableCell>
+                <TableCell>{formatCurrency(expense.amount)}</TableCell>
+                <TableCell className="text-right">
+                  <div className="flex justify-end gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onEdit(expense.id)}
+                    >
+                      <Edit className="h-4 w-4 mr-1" />
+                      Edit
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onDelete(expense.id)}
+                      className="text-red-500 hover:text-red-600"
+                    >
+                      <Trash className="h-4 w-4 mr-1" />
+                      Delete
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+            <TableRow>
+              <TableCell className="font-bold">Total Expenses</TableCell>
+              <TableCell className="font-bold">
+                {formatCurrency(totalExpenses)}
+              </TableCell>
+              <TableCell></TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Mobile view */}
+      <div className="md:hidden space-y-4">
+        {expenses.map((expense) => (
+          <Card key={expense.id} className="w-full">
+            <CardContent className="p-4">
+              <div className="space-y-2">
+                <div className="flex justify-between items-center">
+                  <span className="text-sm font-medium">{expense.name}</span>
+                  <span className="text-lg font-bold">
+                    {formatCurrency(expense.amount)}
+                  </span>
+                </div>
+                <div className="flex justify-end gap-2 pt-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => onEdit(expense.id)}
+                  >
+                    <Edit className="h-4 w-4 mr-1" />
+                    Edit
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => onDelete(expense.id)}
+                    className="text-red-500 hover:text-red-600"
+                  >
+                    <Trash className="h-4 w-4 mr-1" />
+                    Delete
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+
+        {/* Total for Mobile */}
+        <Card className="w-full border-t-2 border-primary">
+          <CardContent className="p-4">
+            <div className="flex justify-between items-center">
+              <span className="font-bold">Total Expenses</span>
+              <span className="text-lg font-bold">
+                {formatCurrency(totalExpenses)}
+              </span>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};

--- a/src/features/core/pages/financial-records/components/financial-record-details.tsx
+++ b/src/features/core/pages/financial-records/components/financial-record-details.tsx
@@ -1,5 +1,5 @@
 import { useParams, Link } from "react-router-dom";
-import { ArrowLeft, Edit } from "lucide-react";
+import { ArrowLeft, Edit, Plus } from "lucide-react";
 import { formatCurrency, formatDate, formatChange } from "@/lib/formatters";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -12,7 +12,12 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { useFinancialRecordDetails } from "../hooks/financial-record-details-hook";
+import { useExpenses } from "../hooks/expenses-hook";
 import { calculateTotal } from "../../../services/financial-functions";
+import { AddExpenseDialog } from "./add-expense-dialog";
+import { EditExpenseDialog } from "./edit-expense-dialog";
+import { DeleteExpenseDialog } from "./delete-expense-dialog";
+import { ExpensesList } from "./expenses-list";
 
 const FinancialRecordDetails = () => {
   // Get record ID from URL params
@@ -276,7 +281,98 @@ const FinancialRecordDetails = () => {
         </CardContent>
       </Card>
 
-      {/* Expenses section would go here when implemented */}
+      {/* Expenses Section */}
+      <Card className="mt-8">
+        <ExpensesSection recordId={record.id} />
+      </Card>
+    </div>
+  );
+};
+
+// Separate component for expenses to keep the main component cleaner
+const ExpensesSection: React.FC<{ recordId: string }> = ({ recordId }) => {
+  const {
+    expenses,
+    isLoading: isLoadingExpenses,
+    error: expensesError,
+    // Add dialog
+    isAddDialogOpen,
+    setIsAddDialogOpen,
+    openAddDialog,
+    addExpense,
+    isAddingExpense,
+    // Edit dialog
+    isEditDialogOpen,
+    setIsEditDialogOpen,
+    openEditDialog,
+    selectedExpense,
+    updateExpense,
+    isUpdatingExpense,
+    // Delete dialog
+    isDeleteDialogOpen,
+    setIsDeleteDialogOpen,
+    openDeleteDialog,
+    selectedExpenseName,
+    deleteExpense,
+    isDeletingExpense,
+  } = useExpenses(recordId);
+
+  if (isLoadingExpenses) {
+    return <div className="p-4">Loading expenses...</div>;
+  }
+
+  if (expensesError) {
+    return <div className="p-4 text-red-500">Error loading expenses</div>;
+  }
+
+  return (
+    <div className="w-full">
+      <div className="flex justify-end mb-4">
+        <CardHeader className="pb-2 flex flex-row items-center justify-between w-full">
+          <CardTitle className="text-lg">Relevant Expenses</CardTitle>
+          <Button onClick={openAddDialog} className="flex items-center gap-1">
+            <Plus className="h-4 w-4" />
+            Add Expense
+          </Button>
+        </CardHeader>
+      </div>
+
+      <CardContent className="p-0">
+        <ExpensesList
+          expenses={expenses}
+          onEdit={openEditDialog}
+          onDelete={openDeleteDialog}
+        />
+      </CardContent>
+
+      {/* Dialogs for adding, editing, and deleting expenses */}
+      <AddExpenseDialog
+        open={isAddDialogOpen}
+        onOpenChange={setIsAddDialogOpen}
+        onSubmit={addExpense}
+        isLoading={isAddingExpense}
+      />
+
+      {selectedExpense && (
+        <EditExpenseDialog
+          open={isEditDialogOpen}
+          onOpenChange={setIsEditDialogOpen}
+          onSubmit={updateExpense}
+          isLoading={isUpdatingExpense}
+          initialData={{
+            name: selectedExpense.name,
+            amount: selectedExpense.amount,
+          }}
+        />
+      )}
+
+      <DeleteExpenseDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+        onConfirm={deleteExpense}
+        isLoading={isDeletingExpense}
+        expenseName={selectedExpenseName}
+      />
     </div>
   );
 };

--- a/src/features/core/pages/financial-records/hooks/expenses-hook.ts
+++ b/src/features/core/pages/financial-records/hooks/expenses-hook.ts
@@ -1,0 +1,155 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { expenseRepository } from "../../../repositories/repository.factory";
+import {
+  CreateExpenseInput,
+  UpdateExpenseInput,
+} from "../../../entities/expense";
+
+/**
+ * Hook for managing expenses for a specific financial record
+ */
+export const useExpenses = (financialRecordId: string) => {
+  const queryClient = useQueryClient();
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [selectedExpenseId, setSelectedExpenseId] = useState<string | null>(
+    null
+  );
+  const [selectedExpenseName, setSelectedExpenseName] = useState("");
+
+  // Get expenses for the financial record
+  const {
+    data: expenses = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["expenses", financialRecordId],
+    queryFn: () =>
+      expenseRepository.getExpensesForFinancialRecord(financialRecordId),
+    enabled: !!financialRecordId,
+  });
+
+  // Add a new expense
+  const addExpenseMutation = useMutation({
+    mutationFn: (data: Omit<CreateExpenseInput, "financialRecordId">) => {
+      return expenseRepository.addExpenseToFinancialRecord({
+        ...data,
+        financialRecordId,
+      });
+    },
+    onSuccess: () => {
+      // Invalidate and refetch the expenses query
+      queryClient.invalidateQueries({
+        queryKey: ["expenses", financialRecordId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["financialRecordPair", financialRecordId],
+      });
+      setIsAddDialogOpen(false);
+    },
+  });
+
+  // Update an expense
+  const updateExpenseMutation = useMutation({
+    mutationFn: (data: { id: string; input: UpdateExpenseInput }) => {
+      return expenseRepository.updateExpense(
+        financialRecordId,
+        data.id,
+        data.input
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["expenses", financialRecordId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["financialRecordPair", financialRecordId],
+      });
+      setIsEditDialogOpen(false);
+      setSelectedExpenseId(null);
+    },
+  });
+
+  // Delete an expense
+  const deleteExpenseMutation = useMutation({
+    mutationFn: (expenseId: string) => {
+      return expenseRepository.deleteExpense(financialRecordId, expenseId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["expenses", financialRecordId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["financialRecordPair", financialRecordId],
+      });
+      setIsDeleteDialogOpen(false);
+      setSelectedExpenseId(null);
+      setSelectedExpenseName("");
+    },
+  });
+
+  // Function to open the add dialog
+  const openAddDialog = () => {
+    setIsAddDialogOpen(true);
+  };
+
+  // Function to open the edit dialog for a specific expense
+  const openEditDialog = (expenseId: string) => {
+    const expense = expenses.find((e) => e.id === expenseId);
+    if (expense) {
+      setSelectedExpenseId(expenseId);
+      setIsEditDialogOpen(true);
+    }
+  };
+
+  // Function to open the delete dialog for a specific expense
+  const openDeleteDialog = (expenseId: string) => {
+    const expense = expenses.find((e) => e.id === expenseId);
+    if (expense) {
+      setSelectedExpenseId(expenseId);
+      setSelectedExpenseName(expense.name);
+      setIsDeleteDialogOpen(true);
+    }
+  };
+
+  // Get the selected expense for editing
+  const selectedExpense = selectedExpenseId
+    ? expenses.find((e) => e.id === selectedExpenseId)
+    : null;
+
+  return {
+    expenses,
+    isLoading,
+    error,
+    // Add dialog
+    isAddDialogOpen,
+    setIsAddDialogOpen,
+    openAddDialog,
+    addExpense: addExpenseMutation.mutate,
+    isAddingExpense: addExpenseMutation.isPending,
+    // Edit dialog
+    isEditDialogOpen,
+    setIsEditDialogOpen,
+    openEditDialog,
+    selectedExpense,
+    updateExpense: (input: UpdateExpenseInput) => {
+      if (selectedExpenseId) {
+        updateExpenseMutation.mutate({ id: selectedExpenseId, input });
+      }
+    },
+    isUpdatingExpense: updateExpenseMutation.isPending,
+    // Delete dialog
+    isDeleteDialogOpen,
+    setIsDeleteDialogOpen,
+    openDeleteDialog,
+    selectedExpenseName,
+    deleteExpense: () => {
+      if (selectedExpenseId) {
+        deleteExpenseMutation.mutate(selectedExpenseId);
+      }
+    },
+    isDeletingExpense: deleteExpenseMutation.isPending,
+  };
+};

--- a/src/features/core/repositories/expense.repository.ts
+++ b/src/features/core/repositories/expense.repository.ts
@@ -1,0 +1,195 @@
+import { v4 as uuidv4 } from "uuid";
+import { ErrorCode, RepositoryError } from "@/lib/errors";
+import {
+  CreateExpenseInput,
+  Expense,
+  UpdateExpenseInput,
+} from "../entities/expense";
+import {
+  loadFinancialRecords,
+  saveFinancialRecords,
+} from "./local-storage.memory";
+
+export class ExpenseRepository {
+  /**
+   * Add a new expense to a financial record
+   */
+  async addExpenseToFinancialRecord(
+    input: CreateExpenseInput
+  ): Promise<Expense> {
+    const financialRecords = loadFinancialRecords();
+    const recordIndex = financialRecords.findIndex(
+      (record) => record.id === input.financialRecordId
+    );
+
+    if (recordIndex === -1) {
+      throw new RepositoryError(
+        "Financial record not found",
+        ErrorCode.NOT_FOUND,
+        { id: input.financialRecordId }
+      );
+    }
+
+    // Create a new expense object
+    const newExpense: Expense = {
+      id: uuidv4(),
+      name: input.name,
+      amount: input.amount,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    // Initialize expenses array if it doesn't exist
+    if (!financialRecords[recordIndex].expenses) {
+      financialRecords[recordIndex].expenses = [];
+    }
+
+    // Add expense to the financial record
+    financialRecords[recordIndex].expenses!.push(newExpense);
+
+    // Update the record's updatedAt timestamp
+    financialRecords[recordIndex].updatedAt = new Date();
+
+    // Save updated records
+    saveFinancialRecords(financialRecords);
+
+    return Promise.resolve(newExpense);
+  }
+
+  /**
+   * Update an expense in a financial record
+   */
+  async updateExpense(
+    financialRecordId: string,
+    expenseId: string,
+    input: UpdateExpenseInput
+  ): Promise<Expense> {
+    const financialRecords = loadFinancialRecords();
+    const recordIndex = financialRecords.findIndex(
+      (record) => record.id === financialRecordId
+    );
+
+    if (recordIndex === -1) {
+      throw new RepositoryError(
+        "Financial record not found",
+        ErrorCode.NOT_FOUND,
+        { id: financialRecordId }
+      );
+    }
+
+    const record = financialRecords[recordIndex];
+
+    if (!record.expenses) {
+      throw new RepositoryError(
+        "No expenses found for this record",
+        ErrorCode.NOT_FOUND,
+        { id: financialRecordId }
+      );
+    }
+
+    const expenseIndex = record.expenses.findIndex(
+      (expense) => expense.id === expenseId
+    );
+
+    if (expenseIndex === -1) {
+      throw new RepositoryError("Expense not found", ErrorCode.NOT_FOUND, {
+        id: expenseId,
+        financialRecordId,
+      });
+    }
+
+    // Update expense properties
+    const updatedExpense = {
+      ...record.expenses[expenseIndex],
+      ...(input.name !== undefined && { name: input.name }),
+      ...(input.amount !== undefined && { amount: input.amount }),
+      updatedAt: new Date(),
+    };
+
+    // Replace the expense in the array
+    record.expenses[expenseIndex] = updatedExpense;
+
+    // Update the record's updatedAt timestamp
+    record.updatedAt = new Date();
+
+    // Save updated records
+    saveFinancialRecords(financialRecords);
+
+    return Promise.resolve(updatedExpense);
+  }
+
+  /**
+   * Delete an expense from a financial record
+   */
+  async deleteExpense(
+    financialRecordId: string,
+    expenseId: string
+  ): Promise<void> {
+    const financialRecords = loadFinancialRecords();
+    const recordIndex = financialRecords.findIndex(
+      (record) => record.id === financialRecordId
+    );
+
+    if (recordIndex === -1) {
+      throw new RepositoryError(
+        "Financial record not found",
+        ErrorCode.NOT_FOUND,
+        { id: financialRecordId }
+      );
+    }
+
+    const record = financialRecords[recordIndex];
+
+    if (!record.expenses) {
+      throw new RepositoryError(
+        "No expenses found for this record",
+        ErrorCode.NOT_FOUND,
+        { id: financialRecordId }
+      );
+    }
+
+    const expenseIndex = record.expenses.findIndex(
+      (expense) => expense.id === expenseId
+    );
+
+    if (expenseIndex === -1) {
+      throw new RepositoryError("Expense not found", ErrorCode.NOT_FOUND, {
+        id: expenseId,
+        financialRecordId,
+      });
+    }
+
+    // Remove expense from array
+    record.expenses.splice(expenseIndex, 1);
+
+    // Update the record's updatedAt timestamp
+    record.updatedAt = new Date();
+
+    // Save updated records
+    saveFinancialRecords(financialRecords);
+
+    return Promise.resolve();
+  }
+
+  /**
+   * Get all expenses for a financial record
+   */
+  async getExpensesForFinancialRecord(
+    financialRecordId: string
+  ): Promise<Expense[]> {
+    const financialRecords = loadFinancialRecords();
+    const record = financialRecords.find(
+      (record) => record.id === financialRecordId
+    );
+
+    if (!record) {
+      throw new RepositoryError(
+        "Financial record not found",
+        ErrorCode.NOT_FOUND,
+        { id: financialRecordId }
+      );
+    }
+
+    return Promise.resolve(record.expenses || []);
+  }
+}

--- a/src/features/core/repositories/financial-record.repository.ts
+++ b/src/features/core/repositories/financial-record.repository.ts
@@ -38,7 +38,6 @@ export class FinancialRecordRepository implements IFinancialRecordRepository {
         { id }
       );
     }
-    console.log("Found record:", record);
     return Promise.resolve(record);
   }
 
@@ -132,9 +131,6 @@ export class FinancialRecordRepository implements IFinancialRecordRepository {
     }
     const current = sortedRecords[currentIndex];
     const previous = sortedRecords[currentIndex + 1];
-
-    console.log("Current record:", current);
-    console.log("Previous record:", previous);
 
     return Promise.resolve({ current, previous });
   }

--- a/src/features/core/repositories/repository.factory.ts
+++ b/src/features/core/repositories/repository.factory.ts
@@ -1,7 +1,9 @@
 import { FinancialRecordRepository } from "./financial-record.repository";
 import { SavingsSourceRepository } from "./savings-source.repository";
+import { ExpenseRepository } from "./expense.repository";
 
 export const savingsSourceRepository = new SavingsSourceRepository();
 export const financialRecordRepository = new FinancialRecordRepository(
   savingsSourceRepository
 );
+export const expenseRepository = new ExpenseRepository();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,5 +6,5 @@ import "./index.css";
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />
-  </StrictMode>,
+  </StrictMode>
 );


### PR DESCRIPTION
This pull request introduces full CRUD (Create, Read, Update, Delete) support for managing relevant expenses within financial records, as well as several improvements and refactorings to the financial record and expense tracking features. The changes include new UI components for adding, editing, deleting, and listing expenses, updates to acceptance criteria and user stories, and a minor entity schema adjustment.

**Expense Management Features:**

* Added new components for expense management:
  - `AddExpenseDialog` for adding new expenses, using form validation with Zod and React Hook Form.
  - `EditExpenseDialog` for editing existing expenses with validation and controlled form state.
  - `DeleteExpenseDialog` for confirming and executing expense deletions.
  - `ExpensesList` for displaying, editing, and deleting expenses in both desktop and mobile views, including total calculation.
* Integrated these components into the `financial-record-details.tsx` page and imported the necessary hooks and utilities. [[1]](diffhunk://#diff-7f263f86de1cc35d6982737f893e4e349e3e62cb38fe3b5264746be96e60070eL2-R2) [[2]](diffhunk://#diff-7f263f86de1cc35d6982737f893e4e349e3e62cb38fe3b5264746be96e60070eR15-R20)

**Acceptance Criteria and User Stories:**

* Updated the acceptance criteria in `planning/stories.md` to reflect completed features for expense management, savings sources, and financial record editing.
* Refactored and reorganized user stories for expense handling, including renumbering US009/US010/US011 to US309/US310/US311 for clarity. 
* Moved the "Delete Financial Record" user story and acceptance criteria for better story structure.

**Schema and Type Adjustments:**

* Removed the `financialRecordId` property from the `Expense` interface, as it is no longer required for the expense entity.
